### PR TITLE
9: Update project to API-only

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 # typed: strict
-class ApplicationController < ActionController::Base
+class ApplicationController < ActionController::API
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,9 @@ Bundler.require(*Rails.groups)
 
 module UltimateTodo
   class Application < Rails::Application
+    # Set project to be API-only
+    config.api_only = true
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,4 +60,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Render debugging information preserving the response format
+  config.debug_exception_response_format = :api
 end


### PR DESCRIPTION
#9 

Update project to API in accordance with Rails guide suggestions since, in the creation of `ultimate-todo-app`, I did not include `--api` in the command.